### PR TITLE
fix: add support for 'custom_identifier' in FilingLogger.log_operation

### DIFF
--- a/piboufilings/core/logger.py
+++ b/piboufilings/core/logger.py
@@ -36,7 +36,8 @@ class FilingLogger:
                     "download_success", 
                     "download_error_message", 
                     "parse_success",
-                    "error_code"
+                    "error_code",
+                    "custom_identifier"
                 ])
     
     def log_operation(
@@ -48,7 +49,8 @@ class FilingLogger:
         download_success: bool = False, 
         download_error_message: Optional[str] = None, 
         parse_success: Optional[bool] = None,
-        error_code: Optional[Any] = None
+        error_code: Optional[Any] = None,
+        custom_identifier: Optional[str] = None
     ) -> None:
         """
         Log a filing operation to the CSV file.
@@ -73,7 +75,8 @@ class FilingLogger:
                 "True" if download_success else "False",
                 download_error_message or "",
                 "True" if parse_success else "False" if parse_success is not None else "",
-                str(error_code) if error_code is not None else ""
+                str(error_code) if error_code is not None else "",
+                custom_identifier or ""
             ])
     
     def get_logs(self) -> pd.DataFrame:
@@ -93,7 +96,8 @@ class FilingLogger:
                 "download_success", 
                 "download_error_message", 
                 "parse_success",
-                "error_code"
+                "error_code",
+                "custom_identifier"
             ])
         
         return pd.read_csv(self.log_file)


### PR DESCRIPTION
## What this PR does

This PR fixes the following error:
> TypeError: FilingLogger.log_operation() got an unexpected keyword argument 'custom_identifier'

### Changes made:
- Added `custom_identifier` as an optional argument to `log_operation` method in `FilingLogger`.
- Updated the CSV log headers and row writer to include `custom_identifier` field.
- Ensures backward compatibility with existing log structure.


